### PR TITLE
SDC: Stupid -> Snazzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@
 
 ## WIP Compilers
 
-* [sdc](https://github.com/snazzy-d/SDC) - The Stupid D Compiler. Written in D. Grows Smarter every day.
+* [sdc](https://github.com/snazzy-d/SDC) - The Snazzy D Compiler. Written in D. Grows Smarter every day.
 
 
 ## Dev Tools


### PR DESCRIPTION
The name was changed in March 2021: https://github.com/snazzy-d/sdc/commit/7933fa47a865bd4b18c6327613c8407127d4e091