### PR TITLE
Add Handy-Httpd to Networking library section

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@
 * [libhttp2](https://github.com/etcimon/libhttp2) -  HTTP/2 library in D, translated from nghttp2
 * [collie](https://github.com/huntlabs/collie) -  An asynchronous event-driven network framework written in dlang, like netty framework in D.
 * [dlang-requests](https://github.com/ikod/dlang-requests) - HTTP client library inspired by python-requests
+* [Handy-Httpd](https://github.com/andrewlalis/handy-httpd) - A simple, lightweight, and well-documented HTTP server that lets you bootstrap ideas and have something up and running in minutes.
 
 *Full stack web frameworks.*
 * [Hunt Framework](https://github.com/huntlabs/hunt-framework/) - Hunt is a high-level D Programming Language Web framework that encourages rapid development and clean, pragmatic design. It lets you build high-performance Web applications quickly and easily.


### PR DESCRIPTION
Adds my own handy-httpd library: https://github.com/andrewlalis/handy-httpd